### PR TITLE
fix: only use first blockquote child as description

### DIFF
--- a/docs/1.guide/index.md
+++ b/docs/1.guide/index.md
@@ -1,7 +1,5 @@
 # Getting Started
 
-Writing docs should be fun and this tool is exactly designed for this!
-
 > [!IMPORTANT]
 > This is an internal tool meant for UnJS docs tooling and not reusable at the moment.
 > These docs are for demonstration purposes only, do not rely on them or this tool!

--- a/docs/2.components/index.md
+++ b/docs/2.components/index.md
@@ -1,6 +1,6 @@
 # Components
 
-> Learn more about components usage
+> Discover the components you can use in your markdown files.
 
 ## Alerts
 

--- a/docs/2.components/index.md
+++ b/docs/2.components/index.md
@@ -1,6 +1,6 @@
 # Components
 
-Discover the components you can use in your markdown files.
+> Learn more about components usage
 
 ## Alerts
 

--- a/layers/core/app/server/plugins/content.ts
+++ b/layers/core/app/server/plugins/content.ts
@@ -1,26 +1,37 @@
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('content:file:afterParse', (file) => {
-    if (file._id.endsWith('.md')) {
-      // Remove first h1 and p from markdown files as they are added to front-matter by default
-      if (file.body?.children?.[0]?.tag === 'h1' && file.title === file.body.children[0].children?.[0]?.value) {
-        file.body.children.shift()
-      }
-      if (file.body?.children?.[0]?.tag === 'p' && file.description === file.body.children[0].children?.[0]?.value) {
-        file.body.children.shift()
-      }
-      // Handle GitHub flavoured markdown blockquotes
-      // https://github.com/orgs/community/discussions/16925
-      for (const node of file.body?.children || []) {
-        if (
-          node.tag === 'blockquote' && // bloquote > p x 2 > span > text
-          ['!NOTE', '!TIP', '!IMPORTANT', '!WARNING', '!CAUTION'].includes(
-            node.children?.[0]?.children?.[0]?.children?.[0]?.value,
-          )
-        ) {
-          node.type = 'element'
-          node.tag = node.children?.[0]?.children?.[0]?.children?.[0]?.value.slice(1).toLowerCase()
-          node.children[0].children.shift()
-        }
+    // Filter out non-markdown files
+    if (!file._id.endsWith('.md')) {
+      return
+    }
+
+    // Remove first h1 from markdown files as it is added to front-matter as title
+    if (file.body?.children?.[0]?.tag === 'h1' && file.title === file.body.children[0].children?.[0]?.value) {
+      file.body.children.shift()
+    }
+
+    // Overide default behavior that duplicates first paragraph as description
+    const firstChild = file.body.children?.[0]
+    const firstChildContent = firstChild?.children?.[0]?.children?.[0]?.value
+    if (firstChild.tag === 'blockquote' && firstChildContent) {
+      file.description = firstChildContent
+      file.body.children.shift()
+    } else {
+      file.description = '' // Avoid duplication
+    }
+
+    // Handle GitHub flavoured markdown blockquotes
+    // https://github.com/orgs/community/discussions/16925
+    for (const node of file.body?.children || []) {
+      if (
+        node.tag === 'blockquote' && // bloquote > p x 2 > span > text
+        ['!NOTE', '!TIP', '!IMPORTANT', '!WARNING', '!CAUTION'].includes(
+          node.children?.[0]?.children?.[0]?.children?.[0]?.value,
+        )
+      ) {
+        node.type = 'element'
+        node.tag = node.children?.[0]?.children?.[0]?.children?.[0]?.value.slice(1).toLowerCase()
+        node.children[0].children.shift()
       }
     }
   })

--- a/layers/core/app/server/plugins/content.ts
+++ b/layers/core/app/server/plugins/content.ts
@@ -10,7 +10,7 @@ export default defineNitroPlugin((nitroApp) => {
       file.body.children.shift()
     }
 
-    // Overide default behavior that duplicates first paragraph as description
+    // Only use the first blockquote as the description
     const firstChild = file.body.children?.[0]
     const firstChildContent = firstChild?.children?.[0]?.children?.[0]?.value
     if (firstChild.tag === 'blockquote' && firstChildContent) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Content stack uses first h1 and (any) paragraph as `title` and `description`.

While it is an initiative way for forcing to have good SEO and a better design, it often makes it hard to write normal markdowns because first paragraph is not always meant for SEO meta!

We added a workaround before but it is not as efficient and still causes duplicates when there is a code block in first paragraph and still **forcess** to use first p as description!

As a fair compromise, this PR changes transform to only use first paragraph as description if is `blockquote` (which also when reading plain markdown, reads simpler to a normal text)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
