### PR TITLE
refactor: use Cookies to store color instead of localStorage

### DIFF
--- a/app/components/color-picker/ColorPicker.vue
+++ b/app/components/color-picker/ColorPicker.vue
@@ -51,6 +51,18 @@ import colors from '#tailwind-config/theme/colors'
 const appConfig = useAppConfig()
 const colorMode = useColorMode()
 
+// last 32 bit unix time stamp
+const cookieExpireDate = new Date(2147483647 * 1000)
+
+const primaryCookie = useCookie('nuxt-ui-primary', { expires: cookieExpireDate })
+if (primaryCookie.value) {
+  appConfig.ui.primary = primaryCookie.value
+}
+const grayCookie = useCookie('nuxt-ui-gray', { expires: cookieExpireDate })
+if (grayCookie.value) {
+  appConfig.ui.gray = grayCookie.value
+}
+
 // Computed
 
 const primaryColors = computed(() =>
@@ -65,7 +77,7 @@ const primary = computed({
   set(option) {
     appConfig.ui.primary = option.value
 
-    window.localStorage.setItem('nuxt-ui-primary', appConfig.ui.primary)
+    primaryCookie.value = appConfig.ui.primary
   },
 })
 
@@ -83,18 +95,7 @@ const gray = computed({
   set(option) {
     appConfig.ui.gray = option.value
 
-    window.localStorage.setItem('nuxt-ui-gray', appConfig.ui.gray)
+    grayCookie.value = appConfig.ui.gray
   },
-})
-
-onMounted(() => {
-  const primary = window.localStorage.getItem('nuxt-ui-primary')
-  if (primary) {
-    appConfig.ui.primary = primary
-  }
-  const gray = window.localStorage.getItem('nuxt-ui-gray')
-  if (gray) {
-    appConfig.ui.gray = gray
-  }
 })
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR changes the way the color choice is stored from `localStorage` to `Cookies`.
This is so that SSR also knows the color choice of the user.
Currently, SSR always sends the default color so you get kinda flash banged if you have a different setting.

I know that the workaround with the Cookie expiration date isn't the cleanest. But I believe it would be worth it for the improved UX. If you disagree or have a better idea of how to fix the problem let me know.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
