### PR TITLE
fix: correct install command for deno

### DIFF
--- a/app/components/global/Pm-Install.vue
+++ b/app/components/global/Pm-Install.vue
@@ -6,7 +6,7 @@ const props = defineProps({
 const codeBlocks = computed(() =>
   packageManagers.map((pm) => ({
     filename: pm.name,
-    code: `${pm.command} ${pm.install} ${props.name}`,
+    code: `${pm.command} ${pm.install}${props.name}`,
     key: pm.name,
   })),
 )

--- a/app/utils/pm.ts
+++ b/app/utils/pm.ts
@@ -1,8 +1,8 @@
 export const packageManagers = [
-  { name: 'npm', command: 'npm', install: 'i', run: 'run ', x: 'npx ' },
-  { name: 'yarn', command: 'yarn', install: 'add', run: '', x: 'yarn dlx ' },
-  { name: 'pnpm', command: 'pnpm', install: 'i', run: '', x: 'pnpm dlx ' },
-  { name: 'bun', command: 'bun', install: 'i', run: 'run ', x: 'bunx ' },
-  { name: 'deno', command: 'deno', install: 'i', run: 'run ', x: 'deno run -A npm:' },
-  // { name: 'auto', command: 'npx nypm', install: 'i', run: 'run ', x: 'npx ' },
+  { name: 'npm', command: 'npm', install: 'i ', run: 'run ', x: 'npx ' },
+  { name: 'yarn', command: 'yarn', install: 'add ', run: '', x: 'yarn dlx ' },
+  { name: 'pnpm', command: 'pnpm', install: 'i ', run: '', x: 'pnpm dlx ' },
+  { name: 'bun', command: 'bun', install: 'i ', run: 'run ', x: 'bunx ' },
+  { name: 'deno', command: 'deno', install: 'i npm:', run: 'run ', x: 'deno run -A npm:' },
+  // { name: 'auto', command: 'npx nypm', install: 'i ', run: 'run ', x: 'npx ' },
 ] as const


### PR DESCRIPTION
## issue

resolve #188 

## description

I modified the PackageManager component to include the `npm:` prefix in the Deno install command, ensuring that it now displays a valid command.

before:
<img width="680" height="194" alt="image" src="https://github.com/user-attachments/assets/2c45fce0-7060-4e37-9b92-764fb879e6ed" />
after:
<img width="740" height="198" alt="image" src="https://github.com/user-attachments/assets/afec66bc-3780-433c-bb71-689a2fc7b0e8" />