### PR TITLE
fix: justify-center hero links when there is no hero code

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -53,7 +53,7 @@ usePageSEO({
   description: landing!.description,
 })
 
-function nornalizeHeroLinks(links: LandingConfig['heroLinks']) {
+function normalizeHeroLinks(links: LandingConfig['heroLinks']) {
   return Object.entries(links || {})
     .map(([key, link], order) => {
       if (!link) {
@@ -82,7 +82,7 @@ const hero = computed(() => {
   return {
     title: landing!._heroMdTitle,
     description: landing!.heroDescription,
-    links: nornalizeHeroLinks(landing!.heroLinks),
+    links: normalizeHeroLinks(landing!.heroLinks),
     withFeatures,
     orientation: landing!.heroCode || withFeatures ? 'horizontal' : 'vertical',
     code: landing!.heroCode,
@@ -139,7 +139,7 @@ const { data: sponsors } = await useAsyncData(() => useSponsors())
 
       <template #links>
         <div class="flex flex-col gap-4">
-          <div class="flex items-center flex-wrap gap-2">
+          <div class="flex items-center flex-wrap gap-2" :class="{ 'justify-center': !hero.code }">
             <UButton v-for="link in hero.links" :key="link.label" v-bind="link" class="!px-6 !py-3"> </UButton>
           </div>
         </div>


### PR DESCRIPTION
Adding `justify-center` to the container of `heroLinks` when `heroCode` is not present to make them aligned better:

|Before|After|
|:-:|:-:|
|<img width="864" height="644" alt="Screenshot 2025-08-02 at 23 00 57" src="https://github.com/user-attachments/assets/0e4c2c5c-19d3-4a4c-b538-4d16723acfca" />|<img width="885" height="626" alt="Screenshot 2025-08-02 at 22 53 11" src="https://github.com/user-attachments/assets/941bdad3-3701-4efe-8923-4856e5683272" />|

_The issue was spotted by @nekomeowww_ on [nitro.build](https://nitro.build/)

#### Misc

* Fixing a tiny typo