### PR TITLE
chore: update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,23 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - run: npm i -fg corepack && corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: 'pnpm'
+
+      - run: corepack enable
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run build
+
       - name: nightly release
-        if: |
-          github.ref_name == 'main' &&
-          !contains(github.event.head_commit.message, '[skip-release]') &&
-          !startsWith(github.event.head_commit.message, 'docs')
+        if: github.ref_name == 'main' &&
+            !contains(github.event.head_commit.message, '[skip-release]') &&
+            !startsWith(github.event.head_commit.message, 'docs')
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc &&
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
           pnpm run changelogen --canary nightly --publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes:
- Changed runs-on to `ubuntu-latest`.
- Removed unnecessary global install of Corepack. `npm i -fg corepack` is odd because you don’t need the `-g` when installing in CI. GitHub’s `actions/setup-node` already supports enabling Corepack for pnpm.
- Kept `if`: condition inline for better readability.