### PR TITLE
fix: shiki light mode colors

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -24,6 +24,11 @@ pre .shiki span.line {
   display: inline;
 }
 
+html.light .shiki,
+html.light .shiki span {
+  color: var(--shiki-light) !important;
+}
+
 main {
   min-height: calc(100vh - 150px);
 }

--- a/cli/setup.mjs
+++ b/cli/setup.mjs
@@ -58,7 +58,6 @@ export async function setupDocs(docsDir, opts = {}) {
         lang: docsconfig.landing.heroCode.lang || "sh",
         defaultColor: "dark",
         themes: {
-          default: "github-dark",
           dark: "github-dark",
           light: "github-light",
         },


### PR DESCRIPTION
In light mode, the light theme is not taking effect because of the missing css:
<img width="521" height="305" alt="image" src="https://github.com/user-attachments/assets/afebae33-9e92-42ba-a23d-0f4a0843b1ae" />


This PR fixes it by:
- Add a CSS rule in `app/assets/main.css` that make `.shiki` to use `var(--shiki-light)` when `html.light` is active, so code blocks render with GitHub Light token colors in light mode.
- Drop the now-unused `default: "github-dark"` entry from the landing hero code Shiki themes in `cli/setup.mjs`; `dark` and `light` are sufficient and `defaultColor: "dark"` already controls the fallback.