### PR TITLE
fix: improve Windows compatibility

### DIFF
--- a/cli/setup.mjs
+++ b/cli/setup.mjs
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { execSync } from "node:child_process";
 import { loadConfig, watchConfig } from "c12";
 import { defu } from "defu";
@@ -37,7 +38,12 @@ export async function setupDocs(docsDir, opts = {}) {
   // Convert markdown to HTML for landing items
   if (docsconfig.landing?.features) {
     const md4w = await import("md4w");
-    await md4w.init();
+    // On Windows, md4w.init() uses url.pathname which produces /C:/path
+    // that gets misinterpreted by fs.readFile as C:\C:\path
+    const md4wWasmPath = fileURLToPath(
+      new URL("./md4w-fast.wasm", import.meta.resolve("md4w")),
+    );
+    await md4w.init(await readFile(md4wWasmPath));
     for (const item of docsconfig.landing.features) {
       if (item.description) {
         item.description = md4w.mdToHtml(item.description);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "true",
     "dev": "pnpm run docs:dev",
     "docs:build": "pnpm run undocs build docs",
-    "docs:dev": "NUXT_DOCS_DEV=1 pnpm run undocs dev docs",
+    "docs:dev": "cross-env NUXT_DOCS_DEV=1 pnpm run undocs dev docs",
     "lint": "oxlint && oxfmt --check",
     "fmt": "oxlint --fix && oxfmt",
     "prepack": "pnpm run build",
@@ -27,7 +27,7 @@
     "profile:cpu": "rm -rf .profile && node --cpu-prof --diagnostic-dir ../.profile bin/cli.mjs dev docs",
     "release": "pnpm run lint && changelogen --release && npm publish && git push --follow-tags",
     "template:dev": "pnpm run undocs dev template",
-    "undocs": "./cli/main.mjs"
+    "undocs": "node ./cli/main.mjs"
   },
   "dependencies": {
     "@headlessui/vue": "^1.7.23",
@@ -59,6 +59,7 @@
     "@nuxt/eslint-config": "^1.15.2",
     "@types/node": "^25.6.0",
     "changelogen": "^0.6.2",
+    "cross-env": "^10.1.0",
     "nitropack": "^2.13.3",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       changelogen:
         specifier: ^0.6.2
         version: 0.6.2(magicast@0.5.2)
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       nitropack:
         specifier: ^2.13.3
         version: 2.13.3
@@ -335,6 +338,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@es-joy/jsdoccomment@0.86.0':
     resolution: {integrity: sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==}
@@ -3353,6 +3359,11 @@ packages:
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -7072,6 +7083,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@es-joy/jsdoccomment@0.86.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -10168,6 +10181,11 @@ snapshots:
   crelt@1.0.6: {}
 
   croner@10.0.1: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

# resolves #218 

## Changes

### 1. Fix md4w wasm loading on Windows (`cli/setup.mjs`)

`md4w.init()` internally resolves the wasm file path using `new URL(wasm, import.meta.url).pathname`, which on Windows produces `/C:/path/to/file`. When passed to Node.js `fs.readFile`, the leading `/` is interpreted as the current drive root, resulting in a malformed path like `C:\C:\path\to\file` and an `ENOENT` error.

**Fix**: Manually resolve the wasm file path using `fileURLToPath` + `import.meta.resolve("md4w")`, read the file buffer via `fs/promises.readFile`, and pass it directly to `md4w.init()`.

### 2. Cross-platform script support (`package.json`)

- Added `cross-env` to the `docs:dev` script, since `VAR=value` syntax is not supported on Windows `cmd.exe`
- Changed `undocs` script from `./cli/main.mjs` to `node ./cli/main.mjs`, as the former cannot be executed directly on Windows without a shebang handler



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling for documentation features, ensuring more reliable setup across operating systems.
* **Chores**
  * Updated development script to use `cross-env` for better cross-platform compatibility.
  * Adjusted CLI command execution for consistency.
  * Added a new development dependency to support environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->