### PR TITLE
fix: banner title styling for better visibility

### DIFF
--- a/src/app/components/ui/Banner.vue
+++ b/src/app/components/ui/Banner.vue
@@ -92,7 +92,7 @@ function normalizeActionColor(color?: string): "primary" | "neutral" | "white" {
       class="flex flex-1 items-center justify-center gap-1.5 text-center font-medium"
     >
       <Icon v-if="icon" :name="icon" class="size-4 shrink-0" />
-      <span class="truncate">{{ title }}</span>
+      <span class="text-pretty">{{ title }}</span>
     </component>
 
     <div v-if="actions?.length" class="flex shrink-0 items-center gap-1.5">


### PR DESCRIPTION
Small styling fix for banners.

Currently a banner with a text too long does neither get truncated nor respect the page width:
<img width="384" height="354" alt="image" src="https://github.com/user-attachments/assets/33a0ea13-1fdf-451e-9e1b-80f0ba57f843" />
<img width="386" height="390" alt="image" src="https://github.com/user-attachments/assets/f0313bc1-1b48-4847-a0a6-777c623681c4" />

Simply letting text wrap solves this nicely:
<img width="381" height="422" alt="image" src="https://github.com/user-attachments/assets/380a7169-17ed-4e5e-8da5-c81037f91669" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Banner titles now wrap across multiple lines instead of being clipped with an ellipsis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->