### PR TITLE
feat: add footer configuration with arbitrary notes support

### DIFF
--- a/docs/.config/docs.yaml
+++ b/docs/.config/docs.yaml
@@ -34,3 +34,7 @@ landing:
     - title: "Deploy anywhere"
       icon: "✨"
       description: "The documentation can be hosted on any static hosting."
+footer:
+  notes:
+    - "Released under the [MIT License](https://github.com/unjs/undocs/blob/main/LICENSE)."
+    - "Hosted on [Vercel](https://vercel.com)."

--- a/docs/2.config/1.index.md
+++ b/docs/2.config/1.index.md
@@ -264,6 +264,23 @@ Documentation directory
 
 Note: This option will be automatically set
 
+### `footer`
+
+Footer configuration
+
+#### `notes`
+
+- **Type**: `string | string[]`
+
+One or more lines of Markdown shown in the footer in place of the site name and short description, for a license, a hosting credit or similar. Each entry is rendered at build time and becomes one line.
+
+```yaml
+footer:
+  notes:
+    - "Released under the [MIT License](https://github.com/unjs/undocs/blob/main/LICENSE)."
+    - "Hosted on [Example](https://www.example.com)."
+```
+
 ### `github`
 
 - **Type**: `string`

--- a/schema/config.d.ts
+++ b/schema/config.d.ts
@@ -49,6 +49,10 @@ export interface DocsConfig {
   };
   branch?: string;
   banner?: BannerProps;
+  footer?: {
+    /** One or more lines of Markdown shown in the footer in place of the site name and short description, for a license, a hosting credit or similar. Each entry is rendered at build time and becomes one line. */
+    notes?: string | string[];
+  };
   versions?: { label: string; to: string; active?: boolean }[];
   /** The accent color of the documentation site, default `mono`: `mono` (no accent — the monochrome default), a Geist hue (blue, red, amber, green, teal, purple, pink), a Tailwind palette name mapped onto the nearest Geist hue, a neutral name as a synonym for `mono`, or any CSS color. Tints links, active navigation and icons; solid buttons stay monochrome. */
   themeColor?: string;

--- a/schema/config.json
+++ b/schema/config.json
@@ -239,6 +239,17 @@
         }
       }
     },
+    "footer": {
+      "type": "object",
+      "description": "Footer configuration",
+      "additionalProperties": false,
+      "properties": {
+        "notes": {
+          "description": "One or more lines of Markdown shown in the footer in place of the site name and short description, for a license, a hosting credit or similar. Each entry is rendered at build time and becomes one line.",
+          "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+        }
+      }
+    },
     "versions": {
       "type": "array",
       "description": "The versions of the documentation site.",

--- a/src/app/components/app/AppFooterNotes.vue
+++ b/src/app/components/app/AppFooterNotes.vue
@@ -5,20 +5,32 @@ const appConfig = useAppConfig();
 </script>
 
 <template>
-  <p class="text-sm text-muted-foreground">
-    <span class="text-foreground font-medium">
-      <AppLink
-        class="text-foreground hover:text-brand"
-        :to="`https://github.com/${appConfig.docs.github}`"
-        target="_blank"
-        >{{ appConfig.site.name }}
-      </AppLink>
-    </span>
-    <template v-if="appConfig.docs.shortDescription">
-      &nbsp;<span class="text-muted-foreground">{{
-        appConfig.docs.shortDescription.replace(/\.$/, "")
-      }}</span
-      >.
+  <div class="flex flex-col gap-1 text-center text-sm text-muted-foreground sm:text-left">
+    <template v-if="appConfig.docs.footer?.notes?.length">
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div
+        v-for="(note, i) in appConfig.docs.footer.notes"
+        :key="i"
+        class="[&_a]:text-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:text-brand"
+        v-html="note"
+      />
     </template>
-  </p>
+
+    <p v-else>
+      <span class="text-foreground font-medium">
+        <AppLink
+          class="text-foreground hover:text-brand"
+          :to="`https://github.com/${appConfig.docs.github}`"
+          target="_blank"
+          >{{ appConfig.site.name }}
+        </AppLink>
+      </span>
+      <template v-if="appConfig.docs.shortDescription">
+        &nbsp;<span class="text-muted-foreground">{{
+          appConfig.docs.shortDescription.replace(/\.$/, "")
+        }}</span
+        >.
+      </template>
+    </p>
+  </div>
 </template>

--- a/src/server/app-config.ts
+++ b/src/server/app-config.ts
@@ -11,7 +11,7 @@ export interface UndocsAppConfig {
   ui: { colors: { primary: string } };
 }
 
-// Fails soft: a missing renderer leaves the snippets as they are.
+/** The build-time Markdown renderer. Fails soft: a missing renderer leaves the snippets as they are. */
 async function loadMarkdown() {
   try {
     const md4x = await import("md4x/wasm");
@@ -23,7 +23,7 @@ async function loadMarkdown() {
   }
 }
 
-// The non-blank notes, or undefined when there is nothing to render.
+/** The non-blank, trimmed `footer.notes`, or undefined when there is nothing to render. */
 function footerNotes(notes: unknown): string[] | undefined {
   const list = (Array.isArray(notes) ? notes : [notes])
     .filter((note): note is string => typeof note === "string" && note.trim() !== "")
@@ -54,8 +54,10 @@ export async function generateAppConfig(docsDir: string): Promise<UndocsAppConfi
   // rendered here, once, so the client never loads md4x. Loaded only when one
   // of them is present.
   const notes = footerNotes(docs.footer?.notes);
-  if (docs.footer && !notes) {
-    // Blank notes are no notes: the footer falls back to the name line.
+  if (docs.footer) {
+    // Nothing reaches the footer but rendered HTML: blank notes, a renderer
+    // that failed to load, or a render that threw all leave the name line in
+    // place rather than raw Markdown (or, for a string, one node per character).
     docs.footer.notes = undefined;
   }
   const md4x = landing?.features || notes ? await loadMarkdown() : undefined;

--- a/src/server/app-config.ts
+++ b/src/server/app-config.ts
@@ -11,6 +11,26 @@ export interface UndocsAppConfig {
   ui: { colors: { primary: string } };
 }
 
+// Fails soft: a missing renderer leaves the snippets as they are.
+async function loadMarkdown() {
+  try {
+    const md4x = await import("md4x/wasm");
+    await md4x.init();
+    return md4x;
+  } catch (error) {
+    console.error("[undocs] failed to load the markdown renderer:", error);
+    return undefined;
+  }
+}
+
+// The non-blank notes, or undefined when there is nothing to render.
+function footerNotes(notes: unknown): string[] | undefined {
+  const list = (Array.isArray(notes) ? notes : [notes])
+    .filter((note): note is string => typeof note === "string" && note.trim() !== "")
+    .map((note) => note.trim());
+  return list.length > 0 ? list : undefined;
+}
+
 export async function generateAppConfig(docsDir: string): Promise<UndocsAppConfig> {
   const docs = await loadDocsConfig(docsDir);
 
@@ -30,10 +50,18 @@ export async function generateAppConfig(docsDir: string): Promise<UndocsAppConfi
   // Boolean `landing` is only an on/off switch.
   const landing = typeof docs.landing === "object" ? docs.landing : undefined;
 
-  if (landing?.features) {
+  // Markdown snippets in the config (feature descriptions, footer notes) are
+  // rendered here, once, so the client never loads md4x. Loaded only when one
+  // of them is present.
+  const notes = footerNotes(docs.footer?.notes);
+  if (docs.footer && !notes) {
+    // Blank notes are no notes: the footer falls back to the name line.
+    docs.footer.notes = undefined;
+  }
+  const md4x = landing?.features || notes ? await loadMarkdown() : undefined;
+
+  if (landing?.features && md4x) {
     try {
-      const md4x = await import("md4x/wasm");
-      await md4x.init();
       for (const item of landing.features) {
         if (item.description) {
           item.description = md4x.renderToHtml(item.description);
@@ -41,6 +69,14 @@ export async function generateAppConfig(docsDir: string): Promise<UndocsAppConfi
       }
     } catch (error) {
       console.error("[undocs] failed to render landing feature markdown:", error);
+    }
+  }
+
+  if (notes && md4x) {
+    try {
+      docs.footer.notes = notes.map((note) => md4x.renderToHtml(note));
+    } catch (error) {
+      console.error("[undocs] failed to render footer notes markdown:", error);
     }
   }
 

--- a/test/server/app-config.test.ts
+++ b/test/server/app-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateAppConfig } from "../../src/server/app-config.ts";
+
+let root: string;
+
+const docsDirFor = async (name: string, config: unknown): Promise<string> => {
+  const base = join(root, name);
+  await mkdir(join(base, "docs", ".config"), { recursive: true });
+  await mkdir(join(base, ".git"), { recursive: true });
+  await writeFile(join(base, "docs", ".config", "docs.json"), JSON.stringify(config));
+  return join(base, "docs");
+};
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "undocs-app-config-"));
+});
+
+afterAll(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("generateAppConfig footer.notes", () => {
+  it("renders each note to inline HTML", async () => {
+    const dir = await docsDirFor("notes-list", {
+      name: "Docs",
+      footer: {
+        notes: ["Released under [MIT](https://example.com/LICENSE).", "Hosted on **Example**."],
+      },
+    });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.footer.notes).toEqual([
+      '<p>Released under <a href="https://example.com/LICENSE">MIT</a>.</p>\n',
+      "<p>Hosted on <strong>Example</strong>.</p>\n",
+    ]);
+  });
+
+  it("accepts a single string and drops blank entries", async () => {
+    const dir = await docsDirFor("notes-string", {
+      name: "Docs",
+      footer: { notes: "  Apache-2.0  " },
+    });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.footer.notes).toEqual(["<p>Apache-2.0</p>\n"]);
+
+    const blank = await docsDirFor("notes-blank", { name: "Docs", footer: { notes: ["", "  "] } });
+    expect((await generateAppConfig(blank)).docs.footer.notes).toBeUndefined();
+  });
+
+  it("leaves the config alone without notes", async () => {
+    const dir = await docsDirFor("no-notes", { name: "Docs" });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.footer).toBeUndefined();
+  });
+});

--- a/test/server/app-config.test.ts
+++ b/test/server/app-config.test.ts
@@ -1,30 +1,24 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, type TestContext } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { generateAppConfig } from "../../src/server/app-config.ts";
 
-let root: string;
-
-const docsDirFor = async (name: string, config: unknown): Promise<string> => {
-  const base = join(root, name);
+// One throwaway tree per test, removed when the test ends. The `.git` dir at
+// its root stops the package.json walk at the fixture (see docs-config.test.ts).
+const docsDirFor = async ({ onTestFinished }: TestContext, config: unknown): Promise<string> => {
+  const base = await mkdtemp(join(tmpdir(), "undocs-app-config-"));
+  onTestFinished(() => rm(base, { recursive: true, force: true }));
   await mkdir(join(base, "docs", ".config"), { recursive: true });
   await mkdir(join(base, ".git"), { recursive: true });
   await writeFile(join(base, "docs", ".config", "docs.json"), JSON.stringify(config));
   return join(base, "docs");
 };
 
-beforeAll(async () => {
-  root = await mkdtemp(join(tmpdir(), "undocs-app-config-"));
-});
+describe.concurrent("generateAppConfig footer.notes", async () => {
+  const { generateAppConfig } = await import("../../src/server/app-config.ts");
 
-afterAll(async () => {
-  if (root) await rm(root, { recursive: true, force: true });
-});
-
-describe("generateAppConfig footer.notes", () => {
-  it("renders each note to inline HTML", async () => {
-    const dir = await docsDirFor("notes-list", {
+  it("renders each note to HTML", async (ctx) => {
+    const dir = await docsDirFor(ctx, {
       name: "Docs",
       footer: {
         notes: ["Released under [MIT](https://example.com/LICENSE).", "Hosted on **Example**."],
@@ -37,21 +31,64 @@ describe("generateAppConfig footer.notes", () => {
     ]);
   });
 
-  it("accepts a single string and drops blank entries", async () => {
-    const dir = await docsDirFor("notes-string", {
-      name: "Docs",
-      footer: { notes: "  Apache-2.0  " },
-    });
+  it("accepts a single string", async (ctx) => {
+    const dir = await docsDirFor(ctx, { name: "Docs", footer: { notes: "  Apache-2.0  " } });
     const { docs } = await generateAppConfig(dir);
     expect(docs.footer.notes).toEqual(["<p>Apache-2.0</p>\n"]);
-
-    const blank = await docsDirFor("notes-blank", { name: "Docs", footer: { notes: ["", "  "] } });
-    expect((await generateAppConfig(blank)).docs.footer.notes).toBeUndefined();
   });
 
-  it("leaves the config alone without notes", async () => {
-    const dir = await docsDirFor("no-notes", { name: "Docs" });
+  it("drops blank entries so the footer falls back", async (ctx) => {
+    const dir = await docsDirFor(ctx, { name: "Docs", footer: { notes: ["", "  "] } });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.footer.notes).toBeUndefined();
+  });
+
+  it("leaves the config alone without notes", async (ctx) => {
+    const dir = await docsDirFor(ctx, { name: "Docs" });
     const { docs } = await generateAppConfig(dir);
     expect(docs.footer).toBeUndefined();
+  });
+});
+
+// Sequential: the mock swaps the module registry, so nothing above may be
+// importing while it is in place.
+describe("generateAppConfig without a markdown renderer", () => {
+  const withoutRenderer = async ({ onTestFinished }: TestContext) => {
+    vi.doMock("md4x/wasm", () => ({
+      init: () => Promise.reject(new Error("no wasm here")),
+      renderToHtml: () => {
+        throw new Error("unreachable");
+      },
+    }));
+    vi.resetModules();
+    onTestFinished(() => {
+      vi.doUnmock("md4x/wasm");
+      vi.resetModules();
+    });
+    return (await import("../../src/server/app-config.ts")).generateAppConfig;
+  };
+
+  it("drops string notes so the footer falls back", async (ctx) => {
+    const generateAppConfig = await withoutRenderer(ctx);
+    const dir = await docsDirFor(ctx, { name: "Docs", footer: { notes: "Apache-2.0" } });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.footer.notes).toBeUndefined();
+  });
+
+  it("drops array notes so the footer falls back", async (ctx) => {
+    const generateAppConfig = await withoutRenderer(ctx);
+    const dir = await docsDirFor(ctx, { name: "Docs", footer: { notes: ["a", "b"] } });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.footer.notes).toBeUndefined();
+  });
+
+  it("leaves feature descriptions as written", async (ctx) => {
+    const generateAppConfig = await withoutRenderer(ctx);
+    const dir = await docsDirFor(ctx, {
+      name: "Docs",
+      landing: { features: [{ title: "t", description: "**bold**" }] },
+    });
+    const { docs } = await generateAppConfig(dir);
+    expect(docs.landing.features[0].description).toBe("**bold**");
   });
 });


### PR DESCRIPTION
Small but useful change in footer's customization.

At times I do need to add license/legal or credit information in the footer of all pages. Since the change was small enough I preferred doing right away even if this gets rewritten or discarded.

My personal opinion also is that if `footer.notes` is populated we do replace the `name+shortDescription` of the project itself. Those interested in keeping them can simply use yaml syntax or manually copy-paste the content. But I'm not against a different approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom Markdown footer notes in documentation site configuration.
  - Notes can be provided as a single line or multiple lines and replace the default site name and description.
  - Blank notes are ignored, and the default footer remains when no valid notes are provided.

- **Documentation**
  - Added configuration reference and YAML examples, including license and hosting links.

- **Tests**
  - Added coverage for note formats, blank entries, fallback behavior, and Markdown rendering failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->